### PR TITLE
Added bugfix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
   - id: generate-image-name
     shell: bash
     run: |
-      if  [[ -n ${{ inputs.image_name }} ]]; then
+      if  [[ -n "${{ inputs.image_name }}" ]]; then
          IMAGE_NAME="${{ inputs.image_name }}"
       elif [[ -n "${{ inputs.name }}" ]]; then
         # A name was specified


### PR DESCRIPTION
Needs quotes if image name isn't specified, otherwise throws error.