### PR TITLE
Fix deprecated set-output command with $GITHUB_OUTPUT (Software-5354)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         echo "No image_name provided and ${{ inputs.context }} is not a directory"
         exit 1
       fi
-      echo "image=${IMAGE_NAME,,}" >>GITHUB_OUTPUT
+      echo "image=${IMAGE_NAME,,}" >> GITHUB_OUTPUT
   - name: Generate tag list
     id: generate-tag-list
     env:

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,7 @@ runs:
         exit 1
       fi
       echo "image=${IMAGE_NAME,,}" >> GITHUB_OUTPUT
+
   - name: Generate tag list
     id: generate-tag-list
     env:
@@ -120,3 +121,4 @@ runs:
         TIMESTAMP_TAG=${{ inputs.timestamp_tag }}
       tags: "${{ steps.generate-tag-list.outputs.taglist }}"
       cache-from: type=local,src=/tmp/.buildx-cache
+

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
         fi
       done
       IFS=,
-      echo "taglist=${tag_list[*]}" >>$GITHUB_OUTPUT
+      echo "taglist=${tag_list[*]}" >> $GITHUB_OUTPUT
 
   - name: Import Docker images from cache
     uses: actions/cache@v2

--- a/action.yml
+++ b/action.yml
@@ -65,8 +65,7 @@ runs:
         echo "No image_name provided and ${{ inputs.context }} is not a directory"
         exit 1
       fi
-      echo "::set-output name=image::${IMAGE_NAME,,}"
-
+      echo "image=${IMAGE_NAME,,}" >>GITHUB_OUTPUT
   - name: Generate tag list
     id: generate-tag-list
     env:
@@ -92,7 +91,7 @@ runs:
         fi
       done
       IFS=,
-      echo "::set-output name=taglist::${tag_list[*]}"
+      echo "taglist=${tag_list[*]}" >>$GITHUB_OUTPUT
 
   - name: Import Docker images from cache
     uses: actions/cache@v2
@@ -121,4 +120,3 @@ runs:
         TIMESTAMP_TAG=${{ inputs.timestamp_tag }}
       tags: "${{ steps.generate-tag-list.outputs.taglist }}"
       cache-from: type=local,src=/tmp/.buildx-cache
-


### PR DESCRIPTION
Replaced with updated syntax echo "KEY=VALUE >>$GITHUB_OUTPUT"